### PR TITLE
Packet version and last completed subscribed message IDs should be persisted.

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -132,6 +132,14 @@ func (s *sessions) StateDelete(id []byte) error {
 	return nil
 }
 
+func (s *sessions) StateGet(id []byte)(*SessionState, error){
+	if elem, ok := s.entries.Load(string(id)); ok {
+		return elem.(*session).state, nil
+	}
+
+	return nil, nil
+}
+
 // Delete
 func (s *sessions) Delete(id []byte) error {
 	s.entries.Delete(string(id))

--- a/types.go
+++ b/types.go
@@ -1,5 +1,6 @@
 package persistence
 
+import ("github.com/VolantMQ/volantmq/packet")
 // Errors persistence errors
 type Errors int
 
@@ -46,6 +47,7 @@ func (e Errors) Error() string {
 type PersistedPacket struct {
 	UnAck    bool
 	ExpireAt string
+	Version  packet.ProtocolVersion
 	Data     []byte
 }
 
@@ -64,6 +66,7 @@ type SessionState struct {
 	Errors        []error
 	Expire        *SessionDelays
 	Version       byte
+	LastCompletedSubscribedMessageUniqueIds *map[string]int64
 }
 
 // SystemState system configuration
@@ -88,6 +91,7 @@ type Subscriptions interface {
 type State interface {
 	StateStore([]byte, *SessionState) error
 	StateDelete([]byte) error
+	StateGet([]byte) (*SessionState, error)
 }
 
 // Retained provider for load/store retained messages

--- a/types.go
+++ b/types.go
@@ -1,8 +1,10 @@
 package persistence
 
-import ("github.com/VolantMQ/volantmq/packet")
 // Errors persistence errors
 type Errors int
+
+// ProtocolVersion describes versions implemented by this package
+type ProtocolVersion byte
 
 const (
 	// ErrInvalidArgs invalid arguments provided
@@ -47,7 +49,7 @@ func (e Errors) Error() string {
 type PersistedPacket struct {
 	UnAck    bool
 	ExpireAt string
-	Version  packet.ProtocolVersion
+	Version  ProtocolVersion
 	Data     []byte
 }
 


### PR DESCRIPTION
save MQTT protocol version for the packet, so when loading packets from the persisted storage, they will be decoded correctly. currently, volantmq reads the version from the first byte which may be wrong.

save last completed subscribed message IDs(nano timestamp, created by the patch for volantmqt when create a new publish packet) in the session state, when session loaded, they can used to de-dup the retained messages. Acorrdingly, the SateGet method was added.